### PR TITLE
Use smoother fast animation timing

### DIFF
--- a/theme-styles-variables.liquid
+++ b/theme-styles-variables.liquid
@@ -411,7 +411,7 @@
     --drawer-animation-speed: 0.2s;
     --animation-values-slow: var(--animation-speed-slow) var(--animation-easing);
     --animation-values: var(--animation-speed) var(--animation-easing);
-    --animation-values-fast: var(--animation-speed-fast) var(--animation-easing);
+    --animation-values-fast: 0.25s cubic-bezier(.25, .8, .25, 1);
     --animation-values-allow-discrete: var(--animation-speed) var(--animation-easing) allow-discrete;
     --animation-timing-hover: cubic-bezier(0.25, 0.46, 0.45, 0.94);
     --animation-timing-active: cubic-bezier(0.5, 0, 0.75, 0);


### PR DESCRIPTION
## Summary
- smoothen `--animation-values-fast` to `0.25s cubic-bezier(.25, .8, .25, 1)`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b125093fac832fb792b0a6e780db8a